### PR TITLE
Add Repositories

### DIFF
--- a/BarSystem.WebApi/Data/BaseRepository.cs
+++ b/BarSystem.WebApi/Data/BaseRepository.cs
@@ -1,0 +1,65 @@
+﻿using BarSystem.WebApi.Interfaces.Data;
+using BarSystem.WebApi.Models.Base;
+using Microsoft.EntityFrameworkCore;
+
+namespace BarSystem.WebApi.Data
+{
+    public abstract class BaseRepository<T> : IBaseRepository<T> where T : Entity
+    {
+        private readonly BarSystemDbContext _dbContext;
+
+        public BaseRepository(BarSystemDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public virtual async Task<T> CreateAsync(T entity)
+        {
+            await _dbContext.Set<T>().AddAsync(entity);
+            await _dbContext.SaveChangesAsync();
+
+            return entity;
+        }
+
+        public virtual async Task<T> UpdateAsync(T entity, int id)
+        {
+            var existingEntity = await GetAsync(id);
+
+            if (existingEntity is null)
+                return null;
+
+            UpdateEntity(existingEntity, entity);
+
+            await _dbContext.SaveChangesAsync();
+
+            return existingEntity;
+        }
+
+        protected abstract void UpdateEntity(T existingEntity, T newEntity);
+
+        public virtual async Task<T> GetAsync(int id)
+        {
+            var entity = await _dbContext.Set<T>().FindAsync(id);
+            return entity;
+        }
+
+        public virtual async Task DeleteAsync(int id)
+        {
+            var entityToDelete = await GetAsync(id);
+            _dbContext.Set<T>().Remove(entityToDelete);
+            await _dbContext.SaveChangesAsync();
+        }
+
+        public virtual async Task<List<T>> GetAllAsync()
+        {
+            var entityList = await _dbContext.Set<T>().ToListAsync();
+            return entityList;
+        }
+
+        public virtual async Task<bool> EntityExistsAsync(int id)
+        {
+            var entityExists = await _dbContext.Set<T>().AnyAsync(e => e.Id == id);
+            return entityExists;
+        }
+    }
+}

--- a/BarSystem.WebApi/Data/DishRepository.cs
+++ b/BarSystem.WebApi/Data/DishRepository.cs
@@ -1,0 +1,22 @@
+﻿using BarSystem.WebApi.Interfaces.Data;
+using BarSystem.WebApi.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BarSystem.WebApi.Data
+{
+    public class DishRepository : BaseRepository<Dish>, IDishRepository
+    {
+        public DishRepository(BarSystemDbContext dbContext) : base(dbContext) { }
+
+        protected override void UpdateEntity(Dish existingDish, Dish newDish)
+        {
+            existingDish.Name = newDish.Name;
+            existingDish.Description = newDish.Description;
+            existingDish.Stock = newDish.Stock;
+            existingDish.Price = newDish.Price;
+            existingDish.Category = newDish.Category;
+            existingDish.EstimatedTime = newDish.EstimatedTime;
+            existingDish.IsReady = newDish.IsReady;
+        }
+    }
+}

--- a/BarSystem.WebApi/Data/DrinkRepository.cs
+++ b/BarSystem.WebApi/Data/DrinkRepository.cs
@@ -1,0 +1,20 @@
+﻿using BarSystem.WebApi.Interfaces.Data;
+using BarSystem.WebApi.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BarSystem.WebApi.Data
+{
+    public class DrinkRepository : BaseRepository<Drink>, IDrinkRepository
+    {
+        public DrinkRepository(BarSystemDbContext dbContext) : base(dbContext) { }
+
+        protected override void UpdateEntity(Drink existingDrink, Drink newDrink)
+        {
+            existingDrink.Name = newDrink.Name;
+            existingDrink.Description = newDrink.Description;
+            existingDrink.Stock = newDrink.Stock;
+            existingDrink.Price = newDrink.Price;
+            existingDrink.Category = newDrink.Category;
+        }
+    }
+}

--- a/BarSystem.WebApi/Data/EmployeeRepository.cs
+++ b/BarSystem.WebApi/Data/EmployeeRepository.cs
@@ -1,0 +1,19 @@
+﻿using BarSystem.WebApi.Interfaces.Data;
+using BarSystem.WebApi.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BarSystem.WebApi.Data
+{
+    public class EmployeeRepository : BaseRepository<Employee>, IEmployeeRepository
+    {
+        public EmployeeRepository(BarSystemDbContext dbContext) : base(dbContext) { }
+
+        protected override void UpdateEntity(Employee existingEmployee, Employee newEmployee)
+        {
+            existingEmployee.Dni = newEmployee.Dni;
+            existingEmployee.FirstName = newEmployee.FirstName;
+            existingEmployee.LastName = newEmployee.LastName;
+            existingEmployee.Role = newEmployee.Role;
+        }
+    }
+}

--- a/BarSystem.WebApi/Data/TableRepository.cs
+++ b/BarSystem.WebApi/Data/TableRepository.cs
@@ -1,0 +1,20 @@
+﻿using BarSystem.WebApi.Interfaces.Data;
+using BarSystem.WebApi.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace BarSystem.WebApi.Data
+{
+    public class TableRepository : BaseRepository<Table>, ITableRepository
+    {
+        public TableRepository(BarSystemDbContext dbContext) : base(dbContext) { }
+
+        protected override void UpdateEntity(Table existingTable, Table newTable)
+        {
+            existingTable.Waiter = newTable.Waiter;
+            existingTable.AmountPeople = newTable.AmountPeople;
+            existingTable.ExistAdult = newTable.ExistAdult;
+            existingTable.Drinks = newTable.Drinks;
+            existingTable.Dishes = newTable.Dishes;
+        }
+    }
+}

--- a/BarSystem.WebApi/Interfaces/Data/IBaseRepository.cs
+++ b/BarSystem.WebApi/Interfaces/Data/IBaseRepository.cs
@@ -1,0 +1,14 @@
+﻿using BarSystem.WebApi.Models.Base;
+
+namespace BarSystem.WebApi.Interfaces.Data
+{
+    public interface IBaseRepository<T> where T : Entity
+    {
+        Task<T> CreateAsync(T entity);
+        Task DeleteAsync(int id);
+        Task<bool> EntityExistsAsync(int id);
+        Task<List<T>> GetAllAsync();
+        Task<T> GetAsync(int id);
+        Task<T> UpdateAsync(T entity, int id);
+    }
+}

--- a/BarSystem.WebApi/Interfaces/Data/IDishRepository.cs
+++ b/BarSystem.WebApi/Interfaces/Data/IDishRepository.cs
@@ -1,0 +1,6 @@
+﻿using BarSystem.WebApi.Models;
+
+namespace BarSystem.WebApi.Interfaces.Data
+{
+    public interface IDishRepository : IBaseRepository<Dish> { }
+}

--- a/BarSystem.WebApi/Interfaces/Data/IDrinkRepository.cs
+++ b/BarSystem.WebApi/Interfaces/Data/IDrinkRepository.cs
@@ -1,0 +1,6 @@
+﻿using BarSystem.WebApi.Models;
+
+namespace BarSystem.WebApi.Interfaces.Data
+{
+    public interface IDrinkRepository : IBaseRepository<Drink> { }
+}

--- a/BarSystem.WebApi/Interfaces/Data/IEmployeeRepository.cs
+++ b/BarSystem.WebApi/Interfaces/Data/IEmployeeRepository.cs
@@ -1,0 +1,6 @@
+﻿using BarSystem.WebApi.Models;
+
+namespace BarSystem.WebApi.Interfaces.Data
+{
+    public interface IEmployeeRepository : IBaseRepository<Employee> { }
+}

--- a/BarSystem.WebApi/Interfaces/Data/ITableRepository.cs
+++ b/BarSystem.WebApi/Interfaces/Data/ITableRepository.cs
@@ -1,0 +1,6 @@
+﻿using BarSystem.WebApi.Models;
+
+namespace BarSystem.WebApi.Interfaces.Data
+{
+    public interface ITableRepository : IBaseRepository<Table> { }
+}


### PR DESCRIPTION
### Background
The Repositories layer was created in order to access Sql Server using EF Core 6.

### Changes
The classes `BaseRepository`, `DishRepository`, `DrinkRepository`, `EmployeeRepository` and `TableRepository` were created with their respective Interfaces.
